### PR TITLE
Ubuntu 23.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/ubuntu-22.04"
+  config.vm.box = "bento/ubuntu-23.04"
   config.vm.box_check_update = true
 
   config.vm.network "private_network", ip: "192.168.56.0"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-23.04"
   config.vm.box_check_update = true
 
+  config.vbguest.auto_update = false if Vagrant.has_plugin?("vagrant-vbguest")
+
   config.vm.network "private_network", ip: "192.168.56.0"
   config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"  # httpd or flask port
   config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"  # nginx port


### PR DESCRIPTION
Use a newer Ubuntu 23.04 and avoid updating vbguest additions to prevent issues with mounting.

```console
==> default: Machine booted and ready!
[default] GuestAdditions versions on your host (7.0.8) and guest (7.0.6) do not match.
Reading package lists...
Building dependency tree...
Reading state information...
Package linux-headers-5.15.0-67-generic is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'linux-headers-5.15.0-67-generic' has no installation candidate
Hit:1 https://download.docker.com/linux/ubuntu jammy InRelease
Hit:2 http://us.archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://us.archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://us.archive.ubuntu.com/ubuntu jammy-backports InRelease
Hit:5 http://us.archive.ubuntu.com/ubuntu jammy-security InRelease
Ign:6 https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 InRelease
Hit:7 https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 Release
Reading package lists...
W: --force-yes is deprecated, use one of the options starting with --allow instead.
Reading package lists...
Building dependency tree...
Reading state information...
Package linux-headers-5.15.0-67-generic is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'linux-headers-5.15.0-67-generic' has no installation candidate
Unmounting Virtualbox Guest Additions ISO from: /mnt
umount: /mnt: not mounted.
==> default: Checking for guest additions in VM...
==> default: Using /Users/mrakitin/VMs/sirepo-raydata-vm for persistent storage.
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

umount /mnt

Stdout from the command:



Stderr from the command:

umount: /mnt: not mounted.
```

Links:
- https://sleeplessbeastie.eu/2022/08/10/how-to-prevent-updating-virtualbox-guest-additions-on-the-guest-system/
- https://stackoverflow.com/questions/37556968/vagrant-disable-guest-additions